### PR TITLE
Fix compatibility with farzai/transport 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,15 @@
   ],
   "require": {
     "php": "^8.2",
-    "farzai/transport": "^1.3.0 || ^2.0.0",
+    "farzai/transport": "^2.0.0",
     "nyholm/psr7": "^1.4",
     "nyholm/psr7-server": "^1.0",
     "symfony/cache": "^7.0"
   },
   "require-dev": {
-    "pestphp/pest": "^2.15 || ^3.0",
+    "guzzlehttp/guzzle": "^7.8",
     "laravel/pint": "^1.0",
+    "pestphp/pest": "^2.15 || ^3.0",
     "spatie/ray": "^1.28"
   },
   "autoload": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -46,6 +46,16 @@ class Client
     }
 
     /**
+     * Set transport.
+     */
+    public function setTransport(Transport $transport): self
+    {
+        $this->transport = $transport;
+
+        return $this;
+    }
+
+    /**
      * Get logger.
      */
     public function getLogger(): LoggerInterface

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -98,11 +98,13 @@ class ClientBuilder
 
         $builder = TransportBuilder::make();
 
+        // Transport 2.x builders are immutable, so each call returns a new
+        // instance that must be captured (1.x returned $this, so this is safe).
         if ($this->httpClient) {
-            $builder->setClient($this->httpClient);
+            $builder = $builder->setClient($this->httpClient);
         }
 
-        $builder->setLogger(
+        $builder = $builder->setLogger(
             $logger = $this->logger ?? new NullLogger(),
         );
 

--- a/src/Endpoints/AbstractEndpoint.php
+++ b/src/Endpoints/AbstractEndpoint.php
@@ -6,6 +6,7 @@ use Farzai\ThaiPost\Authorizer;
 use Farzai\ThaiPost\Client;
 use Farzai\ThaiPost\Contracts\AccessTokenRepositoryInterface;
 use Farzai\ThaiPost\PendingRequest;
+use Farzai\Transport\Transport;
 
 abstract class AbstractEndpoint
 {
@@ -25,8 +26,12 @@ abstract class AbstractEndpoint
     {
         $this->client = clone $client;
 
+        // Transport 2.x uses an immutable config, so rebuild the transport with
+        // the endpoint's base URI instead of mutating it in place.
         $transport = $this->client->getTransport();
-        $transport->setUri($this->getUri());
+        $this->client->setTransport(
+            new Transport($transport->getConfig()->withBaseUri($this->getUri()))
+        );
 
         $this->accessTokenRepository = $accessTokenRepository;
     }

--- a/src/PendingRequest.php
+++ b/src/PendingRequest.php
@@ -4,8 +4,8 @@ namespace Farzai\ThaiPost;
 
 use Farzai\ThaiPost\Contracts\RequestInterceptor;
 use Farzai\Transport\Contracts\ResponseInterface;
-use Farzai\Transport\Request;
 use Farzai\Transport\Response;
+use Nyholm\Psr7\Request;
 use Psr\Http\Message\RequestInterface as PsrRequestInterface;
 use Psr\Http\Message\ResponseInterface as PsrResponseInterface;
 


### PR DESCRIPTION
## Why

The `farzai/transport` constraint was widened to `^1.3.0 || ^2.0.0`, but **2.x is a breaking release the library was never ported to**, so CI was red on every `prefer-stable` job (**20 failing tests**). Two independent breakages:

1. **No PSR-18 client** — transport 2.x no longer bundles a concrete HTTP client (Guzzle is now only a `suggest`), so `Psr18ClientDiscovery` threw `No PSR-18 HTTP client implementation found`.
2. **Removed 2.x APIs** — `Transport::setUri()` and the `Farzai\Transport\Request` class were removed, and both `TransportConfig` and `TransportBuilder` became immutable.

## What changed

- **`AbstractEndpoint`** — transport config is now immutable, so the endpoint's base URI is applied by rebuilding the transport via `TransportConfig::withBaseUri()` instead of the removed `Transport::setUri()`.
- **`ClientBuilder`** — `TransportBuilder` setters now return a *new* instance, so `setClient()` / `setLogger()` return values are captured. Previously they were discarded, silently dropping the injected HTTP client/logger and causing real network calls (403s) during tests. Backwards-compatible: 1.x returned `$this`.
- **`Client`** — added `setTransport()` so an endpoint can swap in its per-endpoint transport on the cloned client.
- **`PendingRequest`** — replaced the removed `Farzai\Transport\Request` with `Nyholm\Psr7\Request` (identical constructor; `nyholm/psr7` is already a direct dependency).
- **`composer.json`** — narrowed the requirement to `farzai/transport ^2.0.0` (the code now uses 2.x-only APIs, so 1.x is no longer supported) and added `guzzlehttp/guzzle` to `require-dev` as a concrete PSR-18 client for the test suite.

## Verification

Ran the full suite locally against **both** transport `2.0.0` (the `prefer-lowest` boundary) and `2.1.0` (`prefer-stable`):

```
Tests: 30 passed (87 assertions)
```

Pint (`--preset psr12`) passes on all changed files.

> Note for consumers: because transport 2.x no longer bundles an HTTP client, applications using this library must now provide their own PSR-18 client (e.g. `composer require guzzlehttp/guzzle`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01614un8EFQbrQChLAkjerix

---
_Generated by [Claude Code](https://claude.ai/code/session_01614un8EFQbrQChLAkjerix)_